### PR TITLE
node-pre-gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -65,6 +65,17 @@
           }
         ]
       ]
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+        {
+          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+          "destination": "<(module_path)"
+        }
+      ]
     }
   ]
 }

--- a/midi.js
+++ b/midi.js
@@ -1,4 +1,9 @@
-var midi = require('bindings')('midi');
+//var midi = require('bindings')('midi');
+var binary = require('node-pre-gyp');
+var path = require('path')
+var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
+var midi = require(binding_path);
+
 var Stream = require('stream');
 
 // MIDI input inherits from EventEmitter
@@ -6,6 +11,7 @@ var EventEmitter = require('events').EventEmitter;
 midi.input.prototype.__proto__ = EventEmitter.prototype;
 
 module.exports = midi;
+
 
 midi.createReadStream = function(input) {
   input = input || new midi.input();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "midi",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "scripts": {
     "preinstall": "npm install node-pre-gyp",
     "install": "node-pre-gyp install --fallback-to-build",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "^2.3.3",
+    "nan": "^2.11.0",
     "node-pre-gyp": "^0.6.39"
   },
   "binary": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "midi",
   "version": "0.9.5",
   "scripts": {
-    "test": "mocha test/unit-tests.js && node test/virtual-loopback-test-automated.js"
+    "preinstall": "npm install node-pre-gyp",
+    "install": "node-pre-gyp install --fallback-to-build",
+    "test": "node test/virtual-loopback-test-automated.js"
   },
   "main": "midi.js",
   "description": "MIDI hardware IO",
@@ -37,7 +39,15 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "^2.3.3"
+    "nan": "^2.3.3",
+    "node-pre-gyp": "^0.6.39"
+  },
+  "binary": {
+    "module_name": "midi",
+    "module_path": "./lib/binding/{configuration}/{node_abi}-{platform}-{arch}/",
+    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz",
+    "host": "https://github.com/aumhaa/node-midi/releases/download/",
+    "remote_path": "{version}"
   },
   "devDependencies": {
     "mocha": ">= 2.1.0",
@@ -45,6 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/justinlatimer/node-midi.git"
-  }
+    "url": "https://github.com/aumhaa/node-midi.git"
+  },
+  "license": "ISC"
 }


### PR DESCRIPTION
You'll need to add pre-built binaries to your releases and edit package.json (line 58) to reflect the c74 git url for this to be self-contained.  Otherwise it will still be looking for the binaries at my fork url (which is fine, until we get out of sync).